### PR TITLE
refactor: replace MongoDB-style naming with clean Prisma conventions …

### DIFF
--- a/client/src/components/FavoriteProjects/FavoriteProjects.tsx
+++ b/client/src/components/FavoriteProjects/FavoriteProjects.tsx
@@ -13,14 +13,14 @@ export default function FavoriteProjects() {
         פרוייקטים נבחרים
       </h2>
       <DataCarousel
-        keyProperty='_id'
+        keyProperty='id'
         dataArray={data}
         containerClassname='max-w-[900px] mx-auto'
-        singleItem={({ mainImage, _id }, index) => (
+        singleItem={({ mainImage, id }, index) => (
           <div className='relative mb-2 aspect-video size-full overflow-hidden rounded-xl'>
-            <Link to={`/projects/${_id}`} state={{ project: data[index] }}>
+            <Link to={`/projects/${id}`} state={{ project: data[index] }}>
               <Image
-                key={_id}
+                key={id}
                 draggable='false'
                 className='size-full object-cover object-center transition-all duration-300 ease-in-out hover:scale-105'
                 src={mainImage}

--- a/client/src/data/shiran.projects.ts
+++ b/client/src/data/shiran.projects.ts
@@ -483,7 +483,7 @@ const p6_imgMain = createResponsiveImage(
 
 // ========== INTERFACE & EXPORTS ==========
 export interface IProject {
-  _id: string;
+  id: string;
   title: string;
   categories: CategoryUrlCode[];
   description: string;
@@ -496,18 +496,13 @@ export interface IProject {
   isCompleted: boolean;
   constructionArea: number;
   favourite: boolean;
-  createdAt?: {
-    $date: string;
-  };
-  updatedAt?: {
-    $date: string;
-  };
-  __v?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export const projects: IProject[] = [
   {
-    _id: '1',
+    id: '1',
     title: 'תכנון ובנייה של בית מגורים לזוג צעיר במושב ילדותם',
     categories: ['privateHouses'],
     description: `זוג צעיר ומקסים הגיע למשרדי לאחר תהליך כואב ומתסכל עם אדריכלית קודמת, שלא הצליחה לפתור את האתגרים שעמדו בפניהם.
@@ -524,7 +519,7 @@ export const projects: IProject[] = [
     favourite: true,
   },
   {
-    _id: '2',
+    id: '2',
     title: 'משפחה, חיבור ועיצוב שמספר סיפור',
     categories: ['privateHouses'],
     description: `זוג צעיר ומקסים, שכבר זכיתי לתכנן עבורם את ביתם הראשון, פנו אליי שוב עם בקשה ייחודית ומלאת משמעות: לתכנן ולעצב עבורם בית חדש, מחובר לבית של אמא אך עם כניסה נפרדת ועצמאות מלאה.
@@ -572,7 +567,7 @@ export const projects: IProject[] = [
     favourite: true,
   },
   {
-    _id: '3',
+    id: '3',
     title: 'בית של חלומות, בים של חיים - מחכה להתגשם',
     categories: ['privateHouses'],
     description: `זוג מקסים עם ארבעה ילדים פנה אליי ללוות אותם בתכנון בית חלומותיהם בפרדס חנה הכפרית. 
@@ -600,7 +595,7 @@ export const projects: IProject[] = [
     favourite: true,
   },
   {
-    _id: '4',
+    id: '4',
     categories: ['privateHouses'],
     client: 'זוג + 2',
     isCompleted: true,
@@ -630,7 +625,7 @@ export const projects: IProject[] = [
     mainImage: p4_imgMain,
   },
   {
-    _id: '5',
+    id: '5',
     categories: ['privateHouses'],
     client: 'זוג',
     isCompleted: true,
@@ -645,7 +640,7 @@ export const projects: IProject[] = [
     mainImage: p5_imgMain,
   },
   {
-    _id: '6',
+    id: '6',
     categories: ['privateHouses'],
     client: 'דירת שותפים',
     isCompleted: true,

--- a/client/src/pages/Project/Project.tsx
+++ b/client/src/pages/Project/Project.tsx
@@ -15,7 +15,7 @@ export default function Project() {
   const { id } = useParams<{ id: string }>();
   const { projects } = useProjects();
 
-  const project = projects.find((p) => p._id === id);
+  const project = projects.find((p) => p.id === id);
 
   if (!project) return <Navigate to='/projects' />;
 
@@ -28,7 +28,7 @@ export default function Project() {
   };
 
   const ogImage = getImageUrl(project.mainImage);
-  const ogUrl = `${BASE_URL}/projects/${project._id}`;
+  const ogUrl = `${BASE_URL}/projects/${project.id}`;
   const description = project.description.split('\n')[0].substring(0, 160) + '...';
   const title = `${project.title} - שירן גלעד אדריכלות ועיצוב פנים`;
 

--- a/client/src/pages/Projects/Projects.tsx
+++ b/client/src/pages/Projects/Projects.tsx
@@ -44,7 +44,7 @@ export default function Projects() {
         </p>
       </div>
       {projectsData.map((e: IProject, i) => (
-        <EnterAnimation key={e._id}>
+        <EnterAnimation key={e.id}>
           <div className={`${i !== 0 ? 'py-5 lg:py-10' : 'py-5 lg:pb-10'}`}>
             <Project project={e} i={i} />
           </div>

--- a/client/src/pages/Projects/components/Project.tsx
+++ b/client/src/pages/Projects/components/Project.tsx
@@ -18,7 +18,7 @@ const Project = ({ project, i }: IProjectProps) => {
       <div className='lg:w-2/3'>
         <EnterAnimation delay={i * 0.1} translateY={false}>
           <Link
-            to={`/projects/${project._id}`}
+            to={`/projects/${project.id}`}
             state={{ project, other: 'other' }}
           >
             <ImageScaleHover
@@ -56,7 +56,7 @@ const Project = ({ project, i }: IProjectProps) => {
                 </Fragment>
               ))}
             <Link
-              to={`/projects/${project._id}`}
+              to={`/projects/${project.id}`}
               className='font-semibold underline'
             >
               עוד על הפרויקט

--- a/rest_request/api-test.rest
+++ b/rest_request/api-test.rest
@@ -8,11 +8,11 @@
 ### 
 ### To get IDs:
 ### 1. First, run: GET {{apiUrl}}/projects (see below)
-### 2. Look at the response - each project has an "_id" field
+### 2. Look at the response - each project has an "id" field
 ### 3. For category IDs, check your database or create categories first
 ### 4. For image IDs, check a project's images array
 ###
-### Example: If a project response shows "_id": "clx123abc456def789", use that
+### Example: If a project response shows "id": "clx123abc456def789", use that
 @projectId = your-project-id-here
 @categoryId = cml45zx5i00002wuc1k1hciui
 @imageId = your-image-id-here
@@ -40,7 +40,7 @@ Content-Type: application/json
 ### Expected Response Format:
 ### [
 ###   {
-###     "_id": "clx123abc456def789",
+###     "id": "clx123abc456def789",
 ###     "title": "Project Title",
 ###     "categories": ["privateHouses"],
 ###     "description": "Project description...",
@@ -53,8 +53,8 @@ Content-Type: application/json
 ###     "isCompleted": true,
 ###     "constructionArea": 100,
 ###     "favourite": false,
-###     "createdAt": { "$date": "2024-01-01T00:00:00.000Z" },
-###     "updatedAt": { "$date": "2024-01-02T00:00:00.000Z" }
+###     "createdAt": "2024-01-01T00:00:00.000Z",
+###     "updatedAt": "2024-01-02T00:00:00.000Z"
 ###   }
 ### ]
 

--- a/server/src/services/project.service.test.ts
+++ b/server/src/services/project.service.test.ts
@@ -91,7 +91,7 @@ describe('projectService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
-        _id: '1',
+        id: '1',
         title: 'Test Project',
         categories: ['privateHouses'],
         mainImage: 'https://example.com/main.jpg',
@@ -192,7 +192,7 @@ describe('projectService', () => {
       const result = await projectService.createProject(createData);
 
       expect(result).toMatchObject({
-        _id: '1',
+        id: '1',
         title: 'New Project',
       });
       expect(projectRepository.create).toHaveBeenCalled();
@@ -377,7 +377,7 @@ describe('projectService', () => {
       const result = await projectService.getProjectById('1');
 
       expect(result).toMatchObject({
-        _id: '1',
+        id: '1',
         title: 'Test Project',
       });
       expect(projectRepository.findById).toHaveBeenCalledWith('1');
@@ -437,7 +437,7 @@ describe('projectService', () => {
       const result = await projectService.updateProject('1', updateData);
 
       expect(result).toMatchObject({
-        _id: '1',
+        id: '1',
         title: 'Updated Title',
       });
       expect(projectRepository.update).toHaveBeenCalled();

--- a/server/src/types/project.types.ts
+++ b/server/src/types/project.types.ts
@@ -15,7 +15,7 @@ export interface ResponsiveImage {
  * Project response matching frontend IProject interface
  */
 export interface ProjectResponse {
-  _id: string;
+  id: string;
   title: string;
   categories: CategoryUrlCode[];
   description: string;
@@ -28,13 +28,8 @@ export interface ProjectResponse {
   isCompleted: boolean;
   constructionArea: number;
   favourite: boolean;
-  createdAt?: {
-    $date: string;
-  };
-  updatedAt?: {
-    $date: string;
-  };
-  __v?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 /**
@@ -116,7 +111,7 @@ export function transformProjectToResponse(
   );
 
   return {
-    _id: project.id,
+    id: project.id,
     title: project.title,
     categories,
     description: project.description,
@@ -129,12 +124,8 @@ export function transformProjectToResponse(
     isCompleted: project.isCompleted,
     constructionArea: project.constructionArea,
     favourite: project.favourite,
-    createdAt: {
-      $date: project.createdAt.toISOString(),
-    },
-    updatedAt: {
-      $date: project.updatedAt.toISOString(),
-    },
+    createdAt: project.createdAt.toISOString(),
+    updatedAt: project.updatedAt.toISOString(),
   };
 }
 

--- a/server/test/integration/project.routes.test.ts
+++ b/server/test/integration/project.routes.test.ts
@@ -134,7 +134,7 @@ describe('Project Routes Integration Tests', () => {
         });
 
       expect(response.status).toBe(201);
-      expect(response.body).toHaveProperty('_id', 'clx123abc456def789');
+      expect(response.body).toHaveProperty('id', 'clx123abc456def789');
       expect(response.body).toHaveProperty('title', 'New Project');
     });
 
@@ -253,7 +253,7 @@ describe('Project Routes Integration Tests', () => {
 
       expect(response.status).toBe(200);
       expect(Array.isArray(response.body)).toBe(true);
-      expect(response.body[0]).toHaveProperty('_id');
+      expect(response.body[0]).toHaveProperty('id');
       expect(response.body[0]).toHaveProperty('title');
     });
 
@@ -328,7 +328,7 @@ describe('Project Routes Integration Tests', () => {
       );
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('_id', 'clx123abc456def789');
+      expect(response.body).toHaveProperty('id', 'clx123abc456def789');
       expect(response.body).toHaveProperty('title', 'Test Project');
     });
 
@@ -384,7 +384,7 @@ describe('Project Routes Integration Tests', () => {
         });
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('_id', 'clx123abc456def789');
+      expect(response.body).toHaveProperty('id', 'clx123abc456def789');
       expect(response.body).toHaveProperty('title', 'Updated Title');
     });
 
@@ -453,7 +453,7 @@ describe('Project Routes Integration Tests', () => {
         });
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('_id', 'clx123abc456def789');
+      expect(response.body).toHaveProperty('id', 'clx123abc456def789');
     });
 
     it('should return 400 when id is missing', async () => {


### PR DESCRIPTION
…in API

Replace _id with id, remove __v, and flatten date objects ({$date: "..."}) to plain ISO strings in the API response contract, matching the actual PostgreSQL/Prisma schema after the database migration.