### PR TITLE
fix: resolve @shirans/shared package for vitest and npm workspaces

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@shirans/shared": "*",
     "@emailjs/browser": "^4.4.1",
     "@hookform/resolvers": "^5.2.2",
     "axios": "^1.13.4",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@shirans/shared": "*",
     "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.3.0",
     "bcrypt": "^6.0.0",

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@shirans/shared': resolve(__dirname, '../shared/src/index.ts'),
     },
   },
 });

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shared",
+  "name": "@shirans/shared",
   "version": "1.0.0",
   "private": true,
   "main": "./dist/index.js",

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,38 @@
+# Monorepo Shared Package Fix
+
+## Root Cause
+
+The shared package had `"name": "shared"` in `package.json`, but all imports use
+`@shirans/shared`. TypeScript and Vite worked via path aliases, but Node.js runtime
+(vitest) could not resolve `@shirans/shared` because npm workspaces never registered
+that package name. This caused 6 test suites to fail with:
+
+```
+Error: Cannot find package '@shirans/shared'
+imported from server/src/constants/httpStatus.ts
+```
+
+## Changes Made
+
+### 1. Rename shared package to `@shirans/shared`
+- [x] `shared/package.json`: `"name": "shared"` → `"name": "@shirans/shared"`
+
+### 2. Add workspace dependency in server and client
+- [x] `server/package.json`: added `"@shirans/shared": "*"` to dependencies
+- [x] `client/package.json`: added `"@shirans/shared": "*"` to dependencies
+- [x] `npm install` from root creates workspace symlinks
+
+### 3. Add `@shirans/shared` alias to vitest.config.ts
+- [x] Mapped `@shirans/shared` → `../shared/src/index.ts` so tests resolve to
+  source directly (no need to build shared before running tests)
+
+## Verification Results
+- [x] `npm install` — workspace symlinks created
+- [x] `cd server && npm run test:run` — **10/10 test files, 128/128 tests pass**
+- [x] `cd client && npm run build` — builds successfully
+- [x] `cd server && npx tsc --noEmit` — zero errors
+
+## Future Improvements (separate PRs)
+- [ ] Type the `buildErrorMessages` function in `errorMessages.ts` (currently uses `any`)
+  — requires updating all consumers to handle `string | ((...args) => string)` union
+- [ ] Add `express-rate-limit` windowMs mock in integration tests (stderr warnings)


### PR DESCRIPTION
Rename shared package from "shared" to "@shirans/shared" so npm workspaces registers the correct package name. Add explicit workspace dependency in server and client package.json. Add vitest alias to resolve @shirans/shared to source files directly.

Fixes 6 failing test suites (128 tests now pass).