### PR TITLE
fix

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,10 +34,6 @@ export default defineConfig({
     trace: 'on-first-retry',
     /* Screenshot on failure */
     screenshot: 'only-on-failure',
-    /* Skip Framer Motion animations so elements are immediately visible in tests */
-    connectOptions: {
-      reducedMotion: 'reduce',
-    },
   },
 
   /* Configure projects for major browsers */

--- a/server/src/docs/swagger/index.ts
+++ b/server/src/docs/swagger/index.ts
@@ -70,5 +70,5 @@ const swaggerDocument = {
 };
 
 export function setupSwagger(app: Express): void {
-  app.use('/', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 }

--- a/server/test/integration/swagger.routes.test.ts
+++ b/server/test/integration/swagger.routes.test.ts
@@ -43,21 +43,21 @@ describe('Swagger API Docs Integration Tests', () => {
 
   describe('GET /docs', () => {
     it('should return 200 with HTML content', async () => {
-      const response = await request(app).get('/docs');
+      const response = await request(app).get('/docs/');
 
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/html/);
     });
 
     it('should contain Swagger UI markup', async () => {
-      const response = await request(app).get('/docs');
+      const response = await request(app).get('/docs/');
 
       expect(response.status).toBe(200);
       expect(response.text).toContain('swagger-ui');
     });
 
     it('should serve swagger UI at root path', async () => {
-      const response = await request(app).get('/docs');
+      const response = await request(app).get('/docs/');
 
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/html/);

--- a/server/test/integration/swagger.routes.test.ts
+++ b/server/test/integration/swagger.routes.test.ts
@@ -41,45 +41,45 @@ describe('Swagger API Docs Integration Tests', () => {
     vi.clearAllMocks();
   });
 
-  describe('GET /api-docs', () => {
+  describe('GET /docs', () => {
     it('should return 200 with HTML content', async () => {
-      const response = await request(app).get('/api-docs/');
+      const response = await request(app).get('/docs');
 
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/html/);
     });
 
     it('should contain Swagger UI markup', async () => {
-      const response = await request(app).get('/api-docs/');
+      const response = await request(app).get('/docs');
 
       expect(response.status).toBe(200);
       expect(response.text).toContain('swagger-ui');
     });
 
     it('should serve swagger UI at root path', async () => {
-      const response = await request(app).get('/');
+      const response = await request(app).get('/docs');
 
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/html/);
     });
   });
 
-  describe('GET /api-docs/swagger-ui-init.js', () => {
+  describe('GET /docs/swagger-ui-init.js', () => {
     it('should serve the swagger initialization script', async () => {
-      const response = await request(app).get('/api-docs/swagger-ui-init.js');
+      const response = await request(app).get('/docs/swagger-ui-init.js');
 
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/javascript/);
     });
 
     it('should contain the API title', async () => {
-      const response = await request(app).get('/api-docs/swagger-ui-init.js');
+      const response = await request(app).get('/docs/swagger-ui-init.js');
 
       expect(response.text).toContain('Shirans Portfolio API');
     });
 
     it('should contain the openapi version', async () => {
-      const response = await request(app).get('/api-docs/swagger-ui-init.js');
+      const response = await request(app).get('/docs/swagger-ui-init.js');
 
       expect(response.text).toContain('3.0.3');
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a route mount change for Swagger UI plus related test updates, with minimal impact outside documentation access paths.
> 
> **Overview**
> Swagger UI is now mounted at `GET /docs` instead of the app root (`/`), and the integration tests are updated to assert the new `/docs` and `/docs/swagger-ui-init.js` endpoints.
> 
> Playwright config removes the `connectOptions.reducedMotion` setting, so tests will no longer force reduced-motion mode by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44ac7e68f9a750916ca0319cdd561b9bc878d18a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->