### PR TITLE
fix(admin): wrap Dashboard in Suspense to prevent sync input error

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -121,7 +121,9 @@ const router = createBrowserRouter([
     path: '/admin',
     element: (
       <ProtectedRoute requireAdmin={true}>
-        <Dashboard />
+        <Suspense fallback={<Loader />}>
+          <Dashboard />
+        </Suspense>
       </ProtectedRoute>
     ),
     children: [


### PR DESCRIPTION
Resolves 'A component suspended while responding to synchronous input' when navigating to /admin - lazy Dashboard now has proper Suspense boundary