### PR TITLE
feat(admin): card layout for DataTable on mobile

### DIFF
--- a/.claude/rules/dont-forget.md
+++ b/.claude/rules/dont-forget.md
@@ -157,3 +157,9 @@ The admin hamburger must match the user-facing `Navbar.tsx`:
 ```
 
 **Reference:** `client/src/components/Admin/AdminNavbar.tsx`, `client/src/components/Navbar/Navbar.tsx`, `client/src/contexts/ScreenProvider.tsx`
+
+### DataTable Mobile Layout
+
+On `isSmallScreen`, `DataTable` renders a **card layout** instead of a table. Each row becomes a vertical card with label-value pairs and actions. Do not override this with custom mobile layouts in page components.
+
+**Reference:** `client/src/components/Admin/DataTable.tsx`, `client/src/contexts/ScreenProvider.tsx`

--- a/client/src/components/Admin/AdminLayout.tsx
+++ b/client/src/components/Admin/AdminLayout.tsx
@@ -124,7 +124,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       )}
 
       {/* Main Content - mr-64 reserves space for fixed sidebar on right (RTL) */}
-      <div className={`flex flex-1 flex-col ${!isSmallScreen ? 'mr-64 min-w-0' : ''}`}>
+      <div className={`flex min-w-0 flex-1 flex-col overflow-x-hidden ${!isSmallScreen ? 'mr-64' : ''}`}>
         <AdminNavbar onMenuToggle={() => setIsSidebarOpen(!isSidebarOpen)} />
         <main className="flex-1 p-6">
           {children}

--- a/client/src/components/Admin/DataTable.tsx
+++ b/client/src/components/Admin/DataTable.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import Loader from '@/components/Loader/Loader';
+import { useScreenContext } from '@/contexts/ScreenProvider';
 
 export interface ColumnConfig<T> {
   key: string;
@@ -27,6 +28,8 @@ export function DataTable<T>({
   actions,
   actionsHeader = 'פעולות',
 }: DataTableProps<T>) {
+  const { isSmallScreen } = useScreenContext();
+
   if (isLoading) {
     return (
       <div className="flex min-h-[200px] items-center justify-center rounded-xl border border-gray-200 bg-white p-8">
@@ -43,6 +46,41 @@ export function DataTable<T>({
         aria-live="polite"
       >
         {emptyMessage}
+      </div>
+    );
+  }
+
+  if (isSmallScreen) {
+    return (
+      <div className="flex flex-col gap-4" role="list">
+        {data.map((row) => (
+          <article
+            key={getRowId(row)}
+            className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+            role="listitem"
+            aria-label={`פריט ${getRowId(row)}`}
+          >
+            <div className="flex flex-col gap-2">
+              {columns.map((col) => (
+                <div key={col.key} className="flex flex-col gap-0.5">
+                  <span className="text-xs font-medium uppercase tracking-wider text-gray-500">
+                    {col.header}
+                  </span>
+                  <div
+                    className={`text-sm text-gray-900 ${col.className ?? ''}`}
+                  >
+                    {col.render(row)}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {actions && (
+              <div className="mt-3 flex flex-wrap gap-2 border-t border-gray-100 pt-3">
+                {actions(row)}
+              </div>
+            )}
+          </article>
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
- DataTable renders cards instead of table when isSmallScreen
- Each row becomes vertical card with label-value pairs and actions
- AdminLayout: min-w-0 overflow-x-hidden to prevent page expansion
- Document DataTable mobile behavior in dont-forget.md