### PR TITLE
feat: fallback to file data when projects/categories/testimonials GET…

### DIFF
--- a/CURSOR.mdc
+++ b/CURSOR.mdc
@@ -4,6 +4,33 @@ alwaysApply: true
 
 # Shirans Project - AI Development Rules
 
+## Before Starting Work (MANDATORY)
+
+**CRITICAL:** Do these steps in order before making any code edits.
+
+### 1. Clarifying Questions First
+
+Before implementing, ask clarifying questions when the task is ambiguous. Examples:
+
+- What exactly is broken? (e.g., which page, which error message?)
+- What is the expected behavior vs what you see?
+- Are there edge cases or constraints to consider?
+- Any environment-specific details? (e.g., production vs dev, browser)
+
+Do **not** assume or guess. If unsure, ask first.
+
+### 2. Git Workflow First
+
+Before any code edits:
+
+1. Create a feature branch: `git checkout -b feature/descriptive-name`
+2. Commit changes incrementally as you work
+3. Never push uncommitted changes to main
+
+If you start editing without a branch, stop and create one first.
+
+---
+
 ## Project Context
 
 This is a full-stack portfolio website for an architecture/interior design professional (Shiran Gilad).
@@ -80,6 +107,7 @@ This is a full-stack portfolio website for an architecture/interior design profe
 ### Branch Strategy
 
 - **CRITICAL:** One feature branch per task/feature
+- **CRITICAL:** Create the branch BEFORE making any code edits
 - Branch naming: `feature/task-name` (e.g., `feature/replace-testimonials`)
 - NEVER work on multiple tasks in the same branch
 - Keep branches focused on single task
@@ -93,7 +121,7 @@ This is a full-stack portfolio website for an architecture/interior design profe
 
 ### Workflow
 
-1. Create feature branch for task
+1. **First:** Create feature branch for task (before any edits)
 2. Make small, logical commits as work progresses
 3. Before pushing: Check for linting/build/TypeScript errors
 4. Push to feature branch (NEVER merge to main)
@@ -358,11 +386,11 @@ throw new HttpError(
 
 ## Questions & Clarifications
 
-**CRITICAL:** If anything is unclear, ask at least 3 clarifying questions before proceeding:
+**CRITICAL:** Ask clarifying questions before implementing. Do not assume.
 
-1. What is the expected behavior?
-2. Are there any edge cases to consider?
-3. What is the user experience goal?
+- When the task is vague or could have multiple interpretations, ask first
+- Examples: "What is the expected behavior?" "Which page/feature is affected?" "Any edge cases?"
+- If unsure, ask before writing code
 
 ---
 

--- a/client/src/contexts/ProjectsContext.tsx
+++ b/client/src/contexts/ProjectsContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { fetchProjects } from '@/services/projects.service';
+import { transformError } from '@/utils/errorHandler';
+import { getClientErrorMessage } from '@/constants/errorMessages';
 import type { ProjectResponse } from '@shirans/shared';
 
 interface ProjectsContextType {
@@ -23,7 +25,10 @@ export const ProjectsProvider = ({ children }: { children: ReactNode }) => {
     setIsLoading(true);
     fetchProjects()
       .then(setProjects)
-      .catch((err) => setError(err.message))
+      .catch((err) => {
+        const appError = transformError(err);
+        setError(getClientErrorMessage(appError.errorKey));
+      })
       .finally(() => setIsLoading(false));
   };
 

--- a/client/src/pages/Project/Project.tsx
+++ b/client/src/pages/Project/Project.tsx
@@ -12,6 +12,8 @@ import type { ProjectResponse, ResponsiveImage } from '@shirans/shared';
 import { BASE_URL } from '@/constants/urls';
 import { LoadingState, ErrorState } from '@/components/DataState';
 import { fetchProject } from '@/services/projects.service';
+import { transformError } from '@/utils/errorHandler';
+import { getClientErrorMessage } from '@/constants/errorMessages';
 
 export default function Project() {
   const { id } = useParams<{ id: string }>();
@@ -31,7 +33,10 @@ export default function Project() {
     setDirectError(null);
     fetchProject(id)
       .then(setDirectProject)
-      .catch((err) => setDirectError(err.message))
+      .catch((err) => {
+        const appError = transformError(err);
+        setDirectError(getClientErrorMessage(appError.errorKey));
+      })
       .finally(() => setDirectLoading(false));
   }, [id, projectFromList, projectsLoading]);
 
@@ -48,7 +53,7 @@ export default function Project() {
   if (directError) {
     return (
       <ErrorState
-        message="פרוייקט לא נמצא"
+        message={directError}
         onRetry={() => navigate('/projects')}
         retryLabel="חזרה לפרויקטים"
       />

--- a/client/src/services/categories.service.ts
+++ b/client/src/services/categories.service.ts
@@ -1,6 +1,7 @@
 import apiClient from '../utils/apiClient';
 import { urls } from '../constants/urls';
 import { USE_FILE_DATA } from '../constants/dataSource';
+import { fetchWithFallback } from '../utils/fetchWithFallback';
 import type { CategoryResponse } from '@shirans/shared';
 
 async function getFileCategories(): Promise<CategoryResponse[]> {
@@ -16,6 +17,9 @@ export async function fetchCategories(): Promise<CategoryResponse[]> {
   if (USE_FILE_DATA) {
     return getFileCategories();
   }
-  const { data } = await apiClient.get<CategoryResponse[]>(urls.categories.getAll);
+  const { data } = await fetchWithFallback(
+    () => apiClient.get<CategoryResponse[]>(urls.categories.getAll).then((r) => r.data),
+    await getFileCategories(),
+  );
   return data;
 }

--- a/client/src/services/projects.service.ts
+++ b/client/src/services/projects.service.ts
@@ -2,6 +2,7 @@ import apiClient from '../utils/apiClient';
 import { urls } from '../constants/urls';
 import { USE_FILE_DATA } from '../constants/dataSource';
 import { resolveImageUrl } from '../utils/imageUrl';
+import { fetchWithFallback } from '../utils/fetchWithFallback';
 import type { ProjectResponse } from '@shirans/shared';
 
 /**
@@ -33,8 +34,14 @@ export async function fetchProjects(): Promise<ProjectResponse[]> {
   if (USE_FILE_DATA) {
     return getFileProjects();
   }
-  const { data } = await apiClient.get<ProjectResponse[]>(urls.projects);
-  return data.map(resolveProjectImages);
+  const { data } = await fetchWithFallback(
+    async () => {
+      const res = await apiClient.get<ProjectResponse[]>(urls.projects);
+      return res.data.map(resolveProjectImages);
+    },
+    await getFileProjects(),
+  );
+  return data;
 }
 
 export async function fetchFavouriteProjects(): Promise<ProjectResponse[]> {
@@ -42,8 +49,15 @@ export async function fetchFavouriteProjects(): Promise<ProjectResponse[]> {
     const projects = await getFileProjects();
     return projects.filter((p) => p.favourite);
   }
-  const { data } = await apiClient.get<ProjectResponse[]>(urls.favProjects);
-  return data.map(resolveProjectImages);
+  const fallback = (await getFileProjects()).filter((p) => p.favourite);
+  const { data } = await fetchWithFallback(
+    async () => {
+      const res = await apiClient.get<ProjectResponse[]>(urls.favProjects);
+      return res.data.map(resolveProjectImages);
+    },
+    fallback,
+  );
+  return data;
 }
 
 export async function fetchProject(id: string): Promise<ProjectResponse> {
@@ -55,8 +69,22 @@ export async function fetchProject(id: string): Promise<ProjectResponse> {
     }
     return project;
   }
-  const { data } = await apiClient.get<ProjectResponse>(urls.singleProject, {
-    params: { id },
-  });
-  return resolveProjectImages(data);
+  const fallbackProjects = await getFileProjects();
+  const fallback = fallbackProjects.find((p) => p.id === id);
+  if (!fallback) {
+    const { data } = await apiClient.get<ProjectResponse>(urls.singleProject, {
+      params: { id },
+    });
+    return resolveProjectImages(data);
+  }
+  const { data } = await fetchWithFallback(
+    async () => {
+      const res = await apiClient.get<ProjectResponse>(urls.singleProject, {
+        params: { id },
+      });
+      return resolveProjectImages(res.data);
+    },
+    fallback,
+  );
+  return data;
 }

--- a/client/src/services/testimonials.service.ts
+++ b/client/src/services/testimonials.service.ts
@@ -1,6 +1,7 @@
 import apiClient from '../utils/apiClient';
 import { urls } from '../constants/urls';
 import { USE_FILE_DATA } from '../constants/dataSource';
+import { fetchWithFallback } from '../utils/fetchWithFallback';
 import type { TestimonialResponse } from '@shirans/shared';
 
 async function getFileTestimonials(): Promise<TestimonialResponse[]> {
@@ -20,8 +21,12 @@ export async function fetchPublishedTestimonials(): Promise<TestimonialResponse[
   if (USE_FILE_DATA) {
     return getFileTestimonials();
   }
-  const { data } = await apiClient.get<TestimonialResponse[]>(
-    urls.testimonials.published,
+  const { data } = await fetchWithFallback(
+    () =>
+      apiClient
+        .get<TestimonialResponse[]>(urls.testimonials.published)
+        .then((r) => r.data),
+    await getFileTestimonials(),
   );
   return data;
 }

--- a/client/src/utils/errorHandler.ts
+++ b/client/src/utils/errorHandler.ts
@@ -28,6 +28,25 @@ export function isNetworkError(error: unknown): boolean {
 }
 
 /**
+ * Check if error should trigger fallback to file data (network error or server down)
+ * Handles both raw Axios errors and AppError (transformed by apiClient interceptor)
+ */
+export function shouldUseFallback(error: unknown): boolean {
+  // AppError from apiClient interceptor (transformed before we catch)
+  if (isAppError(error)) {
+    if (error.isNetworkError) return true;
+    return error.statusCode >= 500 && error.statusCode < 600;
+  }
+  // Raw Axios error (if interceptor is bypassed)
+  if (isNetworkError(error)) return true;
+  if (isAxiosError(error) && error.response) {
+    const status = error.response.status;
+    return status >= 500 && status < 600;
+  }
+  return false;
+}
+
+/**
  * Map HTTP status code to user-friendly Hebrew message
  */
 export function getErrorKeyForStatus(statusCode: number): ErrorKey {

--- a/client/src/utils/fetchWithFallback.ts
+++ b/client/src/utils/fetchWithFallback.ts
@@ -1,0 +1,22 @@
+export type FetchSource = 'api' | 'fallback';
+
+export interface FetchResult<T> {
+  data: T;
+  source: FetchSource;
+}
+
+/**
+ * Tries the API first. On any error, returns fallback data instead of throwing.
+ * Used for projects, categories, and testimonials GET requests.
+ */
+export async function fetchWithFallback<T>(
+  apiFn: () => Promise<T>,
+  fallbackData: T,
+): Promise<FetchResult<T>> {
+  try {
+    const data = await apiFn();
+    return { data, source: 'api' };
+  } catch {
+    return { data: fallbackData, source: 'fallback' };
+  }
+}


### PR DESCRIPTION
… fails

- Add fetchWithFallback utility for API fallback on any error
- Use Hebrew error messages (getClientErrorMessage) in ProjectsContext and Project page
- Add shouldUseFallback to errorHandler (kept for potential future use)
- Update CURSOR.mdc: mandatory git branch + clarifying questions before work