### PR TITLE
fix(deploy): install sharp linux-x64 binaries on Railway

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Install optional deps (platform binaries for sharp, rollup, etc.) on CI/Linux deploys.
+include=optional

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,7 @@
+# Railway server deploy (Nixpacks). Ensures sharp's linux-x64 native binaries install.
+# Same issue as Netlify Rollup — npm may skip optional @img/* packages without this flag.
+[variables]
+NPM_FLAGS = "--include=optional"
+
+[phases.install]
+cmds = ["npm ci", "npm rebuild sharp --workspace=server"]

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,10 @@
     "winston": "^3.19.0",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-linux-x64": "0.34.5"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.58.1",


### PR DESCRIPTION
Railway crashed on startup because npm skipped sharp optional @img packages. Mirror Netlify optional-deps handling via nixpacks and explicit linux pins.